### PR TITLE
Task 412 Firestore implementation in profile screen

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -151,6 +151,87 @@ class AuthService{
       );
     }
   }
+
+  // Specific user Doc
+  Future<Object?> getUserDoc() async {
+    // Get the current user
+    User? user = FirebaseAuth.instance.currentUser;
+
+    if (user != null) {
+      // Fetch the user's document from Firestore
+      DocumentSnapshot userDoc =
+          await _firestore.collection('users').doc(user.uid).get();
+
+      if (userDoc.exists) {
+        // Return userDoc which can be used to access specific
+        // user data
+        return userDoc;
+      }
+    }
+
+    return null; // Return null if no file is found
+  }
+
+  // Fetch User First Name
+  Future<String?> getUserFirstName() async {
+    final userDoc = await getUserDoc();
+
+    if (userDoc != null && userDoc is DocumentSnapshot) {
+      final data = userDoc.data() as Map<String, dynamic>;
+      return data['First_name'] as String?;
+    }
+
+    return null;
+  }
+
+  // Fetch User Last Name
+  Future<String?> getUserLastName() async {
+    final userDoc = await getUserDoc();
+
+    if (userDoc != null && userDoc is DocumentSnapshot) {
+      final data = userDoc.data() as Map<String, dynamic>;
+      return data['Last_name'] as String?;
+    }
+
+    return null;
+  }
+
+  // Fetch User Location
+  Future<String?> getUserLocation() async {
+    final userDoc = await getUserDoc();
+
+    if (userDoc != null && userDoc is DocumentSnapshot) {
+      final data = userDoc.data() as Map<String, dynamic>;
+      return data['Location'] as String?;
+    }
+
+    return null;
+  }
+
+  // Fetch User Phone number
+  Future<String?> getUserPhoneNumber() async {
+    final userDoc = await getUserDoc();
+
+    if (userDoc != null && userDoc is DocumentSnapshot) {
+      final data = userDoc.data() as Map<String, dynamic>;
+      return data['Phone_number'] as String?;
+    }
+
+    return null;
+  }
+
+  // Fetch User email
+  Future<String?> getUserEmail() async {
+    final userDoc = await getUserDoc();
+
+    if (userDoc != null && userDoc is DocumentSnapshot) {
+      final data = userDoc.data() as Map<String, dynamic>;
+      return data['email'] as String?;
+    }
+
+    return null;
+  }
+
   // This feauture is implemented but not used anywhere due to front end not being available at time of development
   // TODO: Implement sign in when front end is available
   

--- a/lib/src/screens/signup_screen.dart
+++ b/lib/src/screens/signup_screen.dart
@@ -7,6 +7,7 @@ import 'package:semester_project__uprm_pet_adoption/services/database_service.da
 import 'package:semester_project__uprm_pet_adoption/src/providers/auth_provider.dart';
 import 'package:semester_project__uprm_pet_adoption/src/screens/gettoknow_screen.dart';
 import 'package:semester_project__uprm_pet_adoption/src/screens/home_screen.dart';
+import 'package:semester_project__uprm_pet_adoption/services/auth_service.dart';
 import 'package:semester_project__uprm_pet_adoption/models/user.dart';
 
 class SignUpScreen extends ConsumerStatefulWidget {
@@ -18,6 +19,7 @@ class SignUpScreen extends ConsumerStatefulWidget {
 
 class _SignUpScreenState extends ConsumerState<SignUpScreen> {
   final DatabaseService _databaseService = DatabaseService();
+  final AuthService authService = AuthService();
 
   final _formKey = GlobalKey<FormState>();
 
@@ -210,23 +212,11 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen> {
                                 if (_formKey.currentState!.validate()) {
                                   AuthService().signup(
                                     email: emailController.text, 
-                                    password: passwordController.text, firstName: '', lastName: '', phoneNumber: ''
-                                    
-
+                                    password: passwordController.text, 
+                                    firstName: firstNameController.text, 
+                                    lastName: lastNameController.text, 
+                                    phoneNumber: ''
                                     );
-                                  //Create user with signup inputs
-                                  User user = User(
-                                      First_name: firstNameController.text,
-                                      Last_name: lastNameController.text,
-                                      Location: "",
-                                      Password: passwordController.text,
-                                      Pet: "",
-                                      Pet_picture: 0,
-                                      Phone_number: "000000000",
-                                      Profile_picture: 0,
-                                      email: emailController.text);
-                                  //Add user to database
-                                  _databaseService.addUser(user);
                                   context.go('/gettoknow');
                                   AnalyticsService().addSignUp();
                                 }


### PR DESCRIPTION
Implemented realtime user profile information update with the ability to modify location and phone number.  Also fixed sign in screen as it was causing problems with my implementation

First of all added functions in auth screen which permit developers to access the current users information.  Made some but the concept is the same for the other fields so if more are needed they may be created.

Used these functions to access current user info such as name, email, location and phone number.  Since for the first time user they do not have a location nor a phone number they may update it them selves in the profile scree. Users are able to interact with location and phone number text fields but not with the user name nor the user email.

In the signup screen I removed the original way of creating the users account as there was a more recent meathod implemented which included a way to find the user uid through auth service much simpler.  The account is created through the signup function in auth service with the relevant information.  Much safer, correct and also solves the problem of a created user not having or not being able to find a uid thus we now have a fully created basic user instead of a blank user with only email and password.