### PR TITLE
added navigation bar at bottom of pet registration

### DIFF
--- a/lib/src/screens/petProfile_screen.dart
+++ b/lib/src/screens/petProfile_screen.dart
@@ -358,6 +358,7 @@ class _PetProfileState extends State<PetProfile> {
           ),
         ),
       ),
+      bottomNavigationBar: const BottomNavBar(selectedIndex: 0),
     );
   }
 


### PR DESCRIPTION
To maintain UI consistency with other screens in the app, this Pull Request adds the bottom navigation bar found in all the other screens of the app, allowing users to go to the home, chat, and user profile screen from the current screen they are in. 